### PR TITLE
[WIP] Add React-Native Support

### DIFF
--- a/src/useRect.js
+++ b/src/useRect.js
@@ -17,7 +17,20 @@ export default function useRect(
   })
 
   useIsomorphicLayoutEffect(() => {
-    if (element && !initialRectSet.current) {
+    /**
+     * React native
+     */
+     if (navigator.product === 'ReactNative' && element && !initialRectSet.current) {
+      initialRectSet.current = true
+      setTimeout(() => element.measure((fx, fy, width, height) => {
+        dispatch({ rect: { width, height } })
+      }), 0)
+    }
+
+    /**
+     * Browser
+     */
+    if (navigator.product !== 'ReactNative' && element && !initialRectSet.current) {
       initialRectSet.current = true
       const rect = element.getBoundingClientRect()
       dispatch({ rect })
@@ -25,7 +38,8 @@ export default function useRect(
   }, [element])
 
   React.useEffect(() => {
-    if (!element) {
+    // * TODO: Handle react native support for observeRect
+    if (navigator.product === 'ReactNative' || !element) {
       return
     }
 


### PR DESCRIPTION
Decouple elements size measurements which uses getBoundingClientRect in browser to add support for React Native view measurement

This patch enables usage of react-virtual on react-native when custom `onScrollElement` and `scrollOffsetFn` props are provided. Added custom `scrollEffect.addEventListener` example in the block below.

```tsx
const onScrollElement = React.useRef({
    addEventListener: (eventName, eventHandler, eventConfig) => {
      scrollEffect.addEventListener(eventHandler)
    },
    removeEventListener: (eventName, eventHandler, eventConfig) => {
      scrollEffect.removeEventListener(eventHandler)
    },
})

const scrollOffsetFn = (event) => {
    if (!event) {
      return 0
    }
    return event.scrollTop
}

const rowVirtualizer = useVirtual({
    size: 1000000,
    parentRef,
    estimateSize: React.useCallback(() => 50, []),
    onScrollElement,
    scrollOffsetFn,
})
```

# Complete Example
<details>
  <summary>Expand code block</summary>

<img src="https://user-images.githubusercontent.com/4882133/154046703-97b5c4d6-bbcd-4172-af17-860f35b3e92d.png" width="220">
  

  ## index.ts
  ```tsx
  import React from 'react';
import {
  StyleSheet,
  ScrollView,
  Text,
  View
} from 'react-native';
import { useVirtual } from 'react-virtual-azim'
import useScrollSubscription from './src/ReactVirtual/useScrollEffect'

const App = () => {
  const parentRef = React.useRef()
  const scrollEffect = useScrollSubscription()

  const onScrollElement = React.useRef({
    addEventListener: (eventName, eventHandler, eventConfig) => {
      scrollEffect.addEventListener(eventHandler)
    },
    removeEventListener: (eventName, eventHandler, eventConfig) => {
      scrollEffect.removeEventListener(eventHandler)
    },
  })

  const scrollOffsetFn = (event) => {
    if (!event) {
      return 0
    }
    return event.scrollTop
  }

  // @ts-ignore
  const rowVirtualizer = useVirtual({
    size: 1000000,
    parentRef,
    estimateSize: React.useCallback(() => 100, []),
    onScrollElement,
    scrollOffsetFn,
  })

  return (
    <ScrollView ref={parentRef} style={styles.container} onScroll={scrollEffect.handleScroll} scrollEventThrottle={16}>
      <View style={[styles.list, { height: rowVirtualizer.totalSize }]}>
        {rowVirtualizer.virtualItems.reverse().map(virtualRow => {
          const isLoaderRow = virtualRow.index + rowVirtualizer.virtualItems.length > 1000 - 1

          return (
            <View
              key={virtualRow.index}
              style={[styles.item, { height: virtualRow.size, transform: [{ translateY: virtualRow.start }] }]}
            >
              <View style={styles.inverted}>
                <Text>{virtualRow.index}</Text>
              </View>
            </View>
          )
        })}
      </View>
    </ScrollView>
  )
};

const styles = StyleSheet.create({
  container: {
    height: '100%',
    width: `100%`,
    backgroundColor: 'red',

    transform: [{
      scaleY: -1
    }]
  },

  list: {
    width: '100%',
    position: 'relative',
    margin: 20,
  },

  item: {
    position: 'absolute',
    top: 0,
    left: 0,
    width: '100%',
  },

  inverted: {
    transform: [{ scaleY: -1 }],
  },
});

export default App;
  ```
  
  
  ## useScrollEffect.ts
  ```tsx
import React from 'react'
import { Dimensions } from 'react-native'

function useScrollSubscription() {
  const scrollSubscriptions = React.useRef([])

  const handleScroll = ({ nativeEvent }) => {
    scrollSubscriptions.current.forEach((callback) => {
      // @ts-ignore
      callback({
        height: Dimensions.get('window').height,
        scrollTop: nativeEvent.contentOffset.y,
      })
    })
  }

  const addEventListener = (callback) => {
    scrollSubscriptions.current.push(callback)
  }

  const removeEventListener = () => {
  }

  return {
    addEventListener,
    removeEventListener,
    handleScroll,
  } 
}

export default useScrollSubscription

```
</details>

# Dynamic size calculation
<details>
  <summary>Expand code block</summary>

Dynamic item height could be calculated by providing `measureRef` function to `onLayout` and have custom `measureSize`

```tsx
const rowVirtualizer = useVirtual({
    measureSize: (el, horizontal, index) => {
      return el.nativeEvent.layout.height
    },
})

...

<View
  onLayout={virtualRow.measureRef}
  style={[styles.item, { transform: [{ translateY: virtualRow.start }] }]}
/>
```

</details>

# Forked version
https://www.npmjs.com/package/react-virtual-azim